### PR TITLE
Pass working dir to incap

### DIFF
--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JavaCompilerArgumentsBuilder.java
@@ -24,6 +24,7 @@ import org.gradle.api.logging.Logger;
 import org.gradle.api.logging.Logging;
 import org.gradle.api.tasks.compile.CompileOptions;
 import org.gradle.api.tasks.compile.ForkOptions;
+import org.gradle.incap.MappingFileConstants;
 import org.gradle.util.DeprecationLogger;
 
 import java.io.File;
@@ -175,6 +176,11 @@ public class JavaCompilerArgumentsBuilder {
             } else {
                 args.add("-processorpath");
                 args.add(Joiner.on(File.pathSeparator).join(annotationProcessorPath));
+                // TODO:  Do we also need to pass -Aincremental?  Does the Annotation Processor need to differentiate?
+                args.add("-A"
+                         + MappingFileConstants.MAPPING_FILE_FOLDER_OPTION
+                         + "="
+                         + spec.getIncrementalAnnotationProcessorWorkingDir());
             }
         }
 

--- a/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
+++ b/subprojects/language-java/src/main/java/org/gradle/api/internal/tasks/compile/JdkJavaCompiler.java
@@ -45,6 +45,9 @@ public class JdkJavaCompiler implements Compiler<JavaCompileSpec>, Serializable 
     public WorkResult execute(JavaCompileSpec spec) {
         LOGGER.info("Compiling with JDK Java compiler API.");
 
+        // Create the incap working dir if necessary.
+        spec.getIncrementalAnnotationProcessorWorkingDir().mkdirs();
+
         JavaCompiler.CompilationTask task = createCompileTask(spec);
         boolean success = task.call();
         if (!success) {


### PR DESCRIPTION
Pass the -Aincap.mapping.file option to incap, if any APs are detected on the path.

This results in a warning being issued (about the option not being recognized by any processor) if none of the APs in the build add incap.mapping.file to their getSupportedOptions() -- something that happens automatically if they extend incap's BaseIncrementalAnnotationProcessor.

To fix the warning properly, I need to add the code for detecting whether any APs participating in the build are incap-compliant, and only pass the -A option if at least one AP is declared as such. I'll do that in a future CL.