### PR TITLE
use snapshots from central for now to share artifacts

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -193,8 +193,7 @@ allprojects {
         maven { url 'https://repo.gradle.org/gradle/libs-releases' }
         maven { url 'https://repo.gradle.org/gradle/libs-milestones' }
         maven { url "https://repo.gradle.org/gradle/libs-snapshots" }
-        //TODO remove this when incap can be published to a repo
-        mavenLocal()
+        maven { url 'https://oss.sonatype.org/content/repositories/snapshots/' }
     }
 
     // patchExternalModules lives in the root project - we need to activate normalization there, too.

--- a/subprojects/language-java/language-java.gradle
+++ b/subprojects/language-java/language-java.gradle
@@ -7,8 +7,8 @@ dependencies {
     compile project(":platformJvm")
     compile project(":languageJvm")
 
-    // // INCAP!
-    compile 'org.gradle.incap:incap-build-client:1.0.0-SNAPSHOT'
+    // INCAP! (using bad groupId for now)
+    compile 'com.github.stephanenicolas:incap-build-client:0.0.1-SNAPSHOT'
 
     // TODO - get rid of this cycle
     integTestRuntime project(':plugins')


### PR DESCRIPTION
After this gets merged, we can share incap artifacts. It's really not a clean setup but at least we can work. We should definitely find a way to deploy artifacts with gradle.

@gstevey Do you need to publish new artifacts of incap. I guess yes .. if so, please tell me.